### PR TITLE
Add try/catch for exec script.

### DIFF
--- a/src/seajs-wrap.js
+++ b/src/seajs-wrap.js
@@ -24,7 +24,7 @@ seajs.on("resolve", function(data) {
         wrapedContent = 'define(function(require, exports, module) {\n' +
                         content + '\n})';
       }
-      globalEval(wrapedContent);
+      globalEval(wrapedContent, uri);
     }
   }
 
@@ -69,10 +69,15 @@ function xhr(url, callback) {
   return r.send(null)
 }
 
-function globalEval(content) {
+function globalEval(content, uri) {
   if (content && /\S/.test(content)) {
     (global.execScript || function(content) {
-      (global.eval || eval).call(global, content)
+      try{
+        (global.eval || eval).call(global, content)
+      }catch(ex){
+        ex.fileName = uri;
+        console.error(ex);
+      }
     })(content)
   }
 }


### PR DESCRIPTION
经常发现语法错误之类的异常（如加载 css 模块），定位到的是 seajs-wrap 的 `eval` 函数，不知道到底哪个模块导致的。
添加 try/catch，便于准确获知抛出异常的模块。

另外对于 css 模块的支持，也可以做到，但是需要对每个 package.json 中声明的依赖进行分析，还要处理加载 css 自身的依赖关系等，有点麻烦。所以还是考虑 [直接编译依赖的方式](https://github.com/hotoo/spm-build-deps)，seajs-wrap 先不做这个了。
